### PR TITLE
Handle missing iOS directory

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -5,13 +5,19 @@ module.exports = ({ rootPath }) => {
   const iosPath = path.resolve(rootPath, 'ios');
   const androidPath = path.resolve(rootPath, 'android');
 
-  const xcodeprojName = fs.readdirSync(iosPath).find(file => path.extname(file) === '.xcodeproj');
+  const iosExists = fs.existsSync(iosPath);
+  const xcodeprojName = iosExists
+    ? fs.readdirSync(iosPath).find(file => path.extname(file) === '.xcodeproj')
+    : null;
+  const pbxprojPath = (xcodeprojName !== null)
+    ? path.resolve(iosPath, xcodeprojName, 'project.pbxproj')
+    : null;
 
   return {
     ios: {
-      exists: fs.existsSync(iosPath),
+      exists: iosExists,
       path: iosPath,
-      pbxprojPath: path.resolve(iosPath, xcodeprojName, 'project.pbxproj'),
+      pbxprojPath,
       sourceDir: iosPath,
     },
     android: {


### PR DESCRIPTION
Currently running the command on a project without an iOS target fails, even if using the Android-only arguments. These changes handle the `/ios` directory missing.

(Changes passed `npm run lint`)