### PR TITLE
1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-asset",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Linking and unlinking of assets in your react-native app, works for fonts and sounds",
   "main": "lib/index.js",
   "bin": "lib/cli.js",


### PR DESCRIPTION
Hi, I ran into an issue where otf files wouldn't get copied and after some debugging realised someone had already taken care of this: https://github.com/unimonkiez/react-native-asset/commit/1b1ec613ea676bf44611a926252c1bfa8d4e542a

Then I realised that the npm module is still on version 1.1.3 and doesn't contain this fix. 

Would be great if you could bump the version and publish the latest version on npm. Thanks and appreciate your hard work on this plugin!