### PR TITLE
Filter files to ignore when writing manifest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ const linkPlatform = ({
   });
 
   manifest.write(assets
+    .filter(filterFilesToIgnore)
     .map(asset => Object.assign(
       {},
       asset,


### PR DESCRIPTION
Unwanted files (.DS_Store, Thumbs.db) are being filtered when copying assets but not when sending to manifest file.
Fixes issue #24 