### PR TITLE
Allow passing a path for the android and iOS project locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Instead this library writes `link-assets-manifest.json` to the root of `android`
 * `-a, --assets` - assets paths, for example `react-native-asset -a ./src/font ./src/mp3`.
 * `-ios-a, --ios-assets` - ios assets paths, will disable android linking
 * `-android-a, --android-assets` - android assets paths, will disable ios linking.
+* `-ios-p, --ios-project-path` - ios project path, if not in `$projectRoot/ios`
+* `-android-p, --android-project-path` - android project path, if not in `$projectRoot/android`
 * `-n-u, --no-unlink` - Not to unlink assets which not longer exists, not recommanded.
 
 ## Backward compatability

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,35 +1,45 @@
 #!/usr/bin/env node
-const path = require('path');
-const linkAssets = require('./index');
-const getCliArgs = require('./cli-args');
+const path = require("path");
+const linkAssets = require("./index");
+const getCliArgs = require("./cli-args");
 
 const options = {
   assets: {
-    cliParams: ['-a', '--assets'],
-    type: 'array',
+    cliParams: ["-a", "--assets"],
+    type: "array",
   },
   iosAssets: {
-    cliParams: ['-ios-a', '--ios-assets'],
-    type: 'array',
+    cliParams: ["-ios-a", "--ios-assets"],
+    type: "array",
   },
   androidAssets: {
-    cliParams: ['-android-a', '--android-assets'],
-    type: 'array',
+    cliParams: ["-android-a", "--android-assets"],
+    type: "array",
   },
   rootPath: {
-    cliParams: ['-p', '--path'],
-    type: 'value',
+    cliParams: ["-p", "--path"],
+    type: "value",
     default: process.cwd(),
   },
+  iosProjectPath: {
+    cliParams: ["-ios-p", "--ios-project-path"],
+    type: "value",
+    default: "ios",
+  },
+  androidProjectPath: {
+    cliParams: ["-android-p", "--android-project-path"],
+    type: "value",
+    default: "android",
+  },
   noUnlink: {
-    cliParams: ['-n-u', '--no-unlink'],
-    type: 'bool',
+    cliParams: ["-n-u", "--no-unlink"],
+    type: "bool",
   },
 };
 
 const cliArgs = getCliArgs(
   process.argv, // .slice(2),
-  options,
+  options
 );
 
 const {
@@ -38,19 +48,24 @@ const {
   assets,
   iosAssets,
   androidAssets,
+  iosProjectPath,
+  androidProjectPath,
 } = cliArgs;
 
 // Using dynamic require for config file, is written in js
 // eslint-disable-next-line import/no-dynamic-require
-const reactNativeConfig = require(path.resolve(rootPath, 'react-native.config.js'));
+const reactNativeConfig = require(path.resolve(
+  rootPath,
+  "react-native.config.js"
+));
 const mutualAssets = (reactNativeConfig.assets || []).concat(assets || []);
 const mergediOSAssets = mutualAssets.concat(
   reactNativeConfig.iosAssets || [],
-  iosAssets || [],
+  iosAssets || []
 );
 const mergedAndroidAssets = mutualAssets.concat(
   reactNativeConfig.androidAssets || [],
-  androidAssets || [],
+  androidAssets || []
 );
 
 linkAssets({
@@ -60,10 +75,12 @@ linkAssets({
     ios: {
       enabled: !(androidAssets && !iosAssets), // when given android but not ios, ok if both not
       assets: mergediOSAssets,
+      projectPath: iosProjectPath,
     },
     android: {
       enabled: !(iosAssets && !androidAssets), // when given ios but not android, ok if both not
       assets: mergedAndroidAssets,
+      projectPath: androidProjectPath,
     },
   },
 });

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = ({ rootPath }) => {
-  const iosPath = path.resolve(rootPath, 'ios');
-  const androidPath = path.resolve(rootPath, 'android');
+module.exports = ({ rootPath, androidProjectPath, iosProjectPath }) => {
+  const iosPath = path.resolve(rootPath, iosProjectPath);
+  const androidPath = path.resolve(rootPath, androidProjectPath);
 
   const iosExists = fs.existsSync(iosPath);
   const xcodeprojName = iosExists

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,14 +178,16 @@ module.exports = ({
     ios: {
       enabled: unl(mergePlatforms.ios.enabled, true),
       assets: mergePlatforms.ios.assets,
+      projectPath: mergePlatforms.ios.projectPath,
     },
     android: {
       enabled: unl(mergePlatforms.android.enabled, true),
       assets: mergePlatforms.android.assets,
+      projectPath: mergePlatforms.android.projectPath,
     },
   };
 
-  const config = getConfig({ rootPath });
+  const config = getConfig({ rootPath, androidProjectPath: platforms.android.projectPath, iosProjectPath: platforms.ios.projectPath, });
   const {
     android: {
       path: androidPath,


### PR DESCRIPTION
The project I'm working on (just an Android app) has an existing android app structure we don't want to modify. Thus our android project is not in the `android` folder of the project root. To be able to link the assets I needed a custom path.

These paths default to the current `android` and `ios` locations unless overriden