### PR TITLE
Add support for Android images

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,8 +205,25 @@ module.exports = ({
     {},
   );
 
+  const imageOptions = {
+    android: {
+      path: path.resolve(androidPath, 'app', 'src', 'main', 'res', 'drawable'),
+    },
+    ios: {
+      addFont: false,
+    },
+  };
+
+  const imageTypes = ['png', 'jpg', 'gif'];
+
+  const imageLinkOptions = imageTypes.reduce(
+    (result, imageFiles) => ({ ...result, [imageFiles]: imageOptions }),
+    {},
+  );
+
   const linkOptionsPerExt = {
     ...fontsLinkOptions,
+    ...imageLinkOptions,
     mp3: {
       android: {
         path: path.resolve(androidPath, 'app', 'src', 'main', 'res', 'raw'),
@@ -253,6 +270,9 @@ module.exports = ({
       linkOptionsPerExt: {
         otf: linkOptionsPerExt.otf.android,
         ttf: linkOptionsPerExt.ttf.android,
+        png: linkOptionsPerExt.png.android,
+        jpg: linkOptionsPerExt.jpg.android,
+        gif: linkOptionsPerExt.gif.android,
         mp3: linkOptionsPerExt.mp3.android,
       },
       otherLinkOptions: otherLinkOptions.android,


### PR DESCRIPTION
Add support for linking png, jpg & gif image assets to the drawable directory on Android.
This implements the enhancement requested in #27 
