### PR TITLE
fix: Adjust asset paths on iOS to resolve relative to the Resources group

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ Instead this library writes `link-assets-manifest.json` to the root of `android`
 
 ## Backward compatability
 * to use react-native 0.59 and below, use version 1.1.4
+
+## Troubleshooting
+
+### iOS
+
+#### No such file or directory
+
+The asset paths in the Xcode project are not correct. Open the project in Xcode, find the offending resource files in the Project Navigator (they will be red), and manually fix the file locations in the *Identify and Type* panel.
+
+During the asset linking stage on iOS, assets are added to the Xcode project as Resource files who's paths are resolved *Relative to Group* by Xcode. The linker uses the default `Resources` group path when generating the paths for the files relative to the Xcode project. While this works for most standard React Native boilerplate, many projects customize the layout of the groups within their project.

--- a/lib/copy-assets/ios.js
+++ b/lib/copy-assets/ios.js
@@ -18,8 +18,15 @@ module.exports = function linkAssetsIOS(files, projectConfig, { addFont }) {
   function addResourceFile(f) {
     return (f || [])
       .map(asset => (
+        // project.addResourceFile adds files `Relative to Group`.
+        // Adding the group name to the projectConfig.sourceDir will generate
+        // correct paths for most standard react-native boilerplate project.
+        //
+        // If a project has already added a `Resources` group and it is nested or
+        // organized in some other way in the project, this will not work and the
+        // assets will have to be manually fixed (see README.md).
         project.addResourceFile(
-          path.relative(projectConfig.sourceDir, asset),
+          path.relative(path.join(projectConfig.sourceDir, group.name), asset),
           { target: project.getFirstTarget().uuid },
         )
       ))


### PR DESCRIPTION
https://github.com/unimonkiez/react-native-asset/issues/43