### PR TITLE
Consider srcDirs when configure app paths

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,4 +66,5 @@ linkAssets({
       assets: mergedAndroidAssets,
     },
   },
+  reactNativeConfig,
 });

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = ({ rootPath, rnConfig }) => {
   const iosPath = path.resolve(rootPath, rnConfig?.project?.ios?.sourceDir ?? 'ios');
-  const androidPath = path.resolve(rootPath, rnConfig?.project?.android?.sourceDir ??'android');
+  const androidPath = path.resolve(rootPath, rnConfig?.project?.android?.sourceDir ?? 'android');
 
   const iosExists = fs.existsSync(iosPath);
   const xcodeprojName = iosExists

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = ({ rootPath }) => {
-  const iosPath = path.resolve(rootPath, 'ios');
-  const androidPath = path.resolve(rootPath, 'android');
+module.exports = ({ rootPath, rnConfig }) => {
+  const iosPath = path.resolve(rootPath, rnConfig?.project?.ios?.sourceDir ?? 'ios');
+  const androidPath = path.resolve(rootPath, rnConfig?.project?.android?.sourceDir ??'android');
 
   const iosExists = fs.existsSync(iosPath);
   const xcodeprojName = iosExists

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,6 +160,7 @@ module.exports = ({
   rootPath: rootPathMightNotAbsolute = cwd,
   shouldUnlink = true,
   platforms: mergePlatforms,
+  reactNativeConfig: rnConfig
 }) => {
   if (!fs.lstatSync(rootPathMightNotAbsolute).isDirectory()) {
     throw new Error(`'rootPath' must be a valid path, got ${rootPathMightNotAbsolute}`);
@@ -185,7 +186,11 @@ module.exports = ({
     },
   };
 
-  const config = getConfig({ rootPath });
+  const config = getConfig({ rootPath, rnConfig });
+
+  console.log(`react-native-asset config:`);
+  console.log(config);
+
   const {
     android: {
       path: androidPath,


### PR DESCRIPTION
Considering react-native-config srcDirs when identify ios and andoid project directories