### PR TITLE
Link assets for all iOS targets

### DIFF
--- a/src/clean-assets/ios.ts
+++ b/src/clean-assets/ios.ts
@@ -4,6 +4,7 @@ import * as xcode from "xcode";
 import createGroupWithMessage from "../react-native-lib/ios/createGroupWithMessage.js";
 import getPlist from "../react-native-lib/ios/getPlist.js";
 import writePlist from "../react-native-lib/ios/writePlist.js";
+import { getTargetUUIDs } from "../utils.ts";
 
 export default async function cleanAssetsIos(
   filePaths: string[],
@@ -11,33 +12,32 @@ export default async function cleanAssetsIos(
   options: { addFont: boolean },
 ) {
   const project = xcode.project(platformConfig.pbxprojPath).parseSync();
-  const plist = await getPlist(
-    project,
-    platformConfig
-      .path,
-  );
 
   createGroupWithMessage(project, "Resources");
 
-  const removedFiles = filePaths.map((p) => {
-    return project.removeResourceFile(
-      path.relative(platformConfig.path, p),
-      { target: project.getFirstTarget().uuid },
-    );
-  }).filter((x) => x).map((file) => file.basename);
+  for (const targetUUID of getTargetUUIDs(project)) {
+    const plist = await getPlist(project, platformConfig.path, targetUUID);
 
-  if (options.addFont) {
-    const existingFonts = plist.UIAppFonts || [];
-    const allFonts = existingFonts.filter((file: string) =>
-      removedFiles.indexOf(file) === -1
-    );
-    plist.UIAppFonts = Array.from(new Set(allFonts)); // use Set to dedupe w/existing
+    const removedFiles = filePaths.map((p) => {
+      return project.removeResourceFile(
+        path.relative(platformConfig.path, p),
+        { target: targetUUID },
+      );
+    }).filter((x) => x).map((file) => file.basename);
+
+    if (options.addFont) {
+      const existingFonts = plist.UIAppFonts || [];
+      const allFonts = existingFonts.filter((file: string) =>
+        removedFiles.indexOf(file) === -1
+      );
+      plist.UIAppFonts = Array.from(new Set(allFonts)); // use Set to dedupe w/existing
+    }
+
+    await writePlist(project, platformConfig.path, plist, targetUUID);
   }
 
   await Deno.writeTextFile(
     platformConfig.pbxprojPath,
     project.writeSync(),
   );
-
-  writePlist(project, platformConfig.path, plist);
 }

--- a/src/copy-assets/ios.ts
+++ b/src/copy-assets/ios.ts
@@ -6,6 +6,7 @@ import * as xcodeParser from "xcode/lib/parser/pbxproj.js";
 import createGroupWithMessage from "../react-native-lib/ios/createGroupWithMessage.js";
 import getPlist from "../react-native-lib/ios/getPlist.js";
 import writePlist from "../react-native-lib/ios/writePlist.js";
+import { getTargetUUIDs } from "../utils.ts";
 
 export default async function cleanAssetsIos(
   filePaths: string[],
@@ -22,32 +23,30 @@ export default async function cleanAssetsIos(
   project.hash = xcodeParser.parse(
     pbxprojContent,
   );
-  const plist = await getPlist(
-    project,
-    platformConfig
-      .path,
-  );
 
   createGroupWithMessage(project, "Resources");
 
-  const addedFiles = filePaths.map((p) =>
-    project.addResourceFile(
-      path.relative(platformConfig.path, p),
-      { target: project.getFirstTarget().uuid },
-    )
-  ).filter((x) => x)
-    .map((file) => file.basename);
+  for (const targetUUID of getTargetUUIDs(project)) {
+    const plist = await getPlist(project, platformConfig.path, targetUUID);
 
-  if (options.addFont) {
-    const existingFonts = plist.UIAppFonts || [];
-    const allFonts = [...existingFonts, ...addedFiles];
-    plist.UIAppFonts = Array.from(new Set(allFonts)); // use Set to dedupe w/existing
+    const addedFiles = filePaths.map((p) =>
+      project.addResourceFile(
+        path.relative(platformConfig.path, p),
+        { target: targetUUID },
+      )
+    ).filter((x) => x).map((file) => file.basename);
+
+    if (options.addFont) {
+      const existingFonts = plist.UIAppFonts || [];
+      const allFonts = [...existingFonts, ...addedFiles];
+      plist.UIAppFonts = Array.from(new Set(allFonts)); // use Set to dedupe w/existing
+    }
+
+    await writePlist(project, platformConfig.path, plist, targetUUID);
   }
 
   await Deno.writeTextFile(
     platformConfig.pbxprojPath,
     project.writeSync(),
   );
-
-  await writePlist(project, platformConfig.path, plist);
 }

--- a/src/react-native-lib/ios/getBuildProperty.js
+++ b/src/react-native-lib/ios/getBuildProperty.js
@@ -5,19 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { getTargetByUUID } from "../../utils.ts";
+
 /**
  * Gets build property from the main target build section
  *
  * It differs from the project.getBuildProperty exposed by xcode in the way that:
- * - it only checks for build property in the main target `Debug` section
  * - `xcode` library iterates over all build sections and because it misses
  * an early return when property is found, it will return undefined/wrong value
  * when there's another build section typically after the one you want to access
  * without the property defined (e.g. CocoaPods sections appended to project
  * miss INFOPLIST_FILE), see: https://github.com/alunny/node-xcode/blob/master/lib/pbxProject.js#L1765
  */
-export default function getBuildProperty(project, prop) {
-  const target = project.getFirstTarget().firstTarget;
+export default function getBuildProperty(project, prop, targetUUID) {
+  const target = getTargetByUUID(project, targetUUID);
   const config =
     project.pbxXCConfigurationList()[target.buildConfigurationList];
   const buildSection = project.pbxXCBuildConfigurationSection()[

--- a/src/react-native-lib/ios/getPlist.js
+++ b/src/react-native-lib/ios/getPlist.js
@@ -13,8 +13,8 @@ import getPlistPath from "./getPlistPath.js";
  *
  * Returns `null` if INFOPLIST_FILE is not specified.
  */
-export default async function getPlist(project, sourceDir) {
-  const plistPath = getPlistPath(project, sourceDir);
+export default async function getPlist(project, sourceDir, targetUUID) {
+  const plistPath = getPlistPath(project, sourceDir, targetUUID);
 
   if (
     !plistPath ||

--- a/src/react-native-lib/ios/getPlistPath.js
+++ b/src/react-native-lib/ios/getPlistPath.js
@@ -8,8 +8,8 @@
 import * as path from "@std/path";
 import getBuildProperty from "./getBuildProperty.js";
 
-export default function getPlistPath(project, sourceDir) {
-  const plistFile = getBuildProperty(project, "INFOPLIST_FILE");
+export default function getPlistPath(project, sourceDir, targetUUID) {
+  const plistFile = getBuildProperty(project, "INFOPLIST_FILE", targetUUID);
 
   if (!plistFile) {
     return null;

--- a/src/react-native-lib/ios/writePlist.js
+++ b/src/react-native-lib/ios/writePlist.js
@@ -13,8 +13,13 @@ import getPlistPath from "./getPlistPath.js";
  *
  * Returns `null` if INFOPLIST_FILE is not specified or file is non-existent.
  */
-export default async function writePlist(project, sourceDir, plist) {
-  const plistPath = getPlistPath(project, sourceDir);
+export default async function writePlist(
+  project,
+  sourceDir,
+  plist,
+  targetUUID,
+) {
+  const plistPath = getPlistPath(project, sourceDir, targetUUID);
 
   if (!plistPath) {
     return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+/// <reference types="./xcode.d.ts" />
+import type xcode from "xcode";
+
+/**
+ * Get an array containing the UUID of each target in the project
+ */
+export function getTargetUUIDs(project: xcode.Project): string[] {
+  return project.getFirstProject().firstProject.targets.map((t) => t.value);
+}
+
+/**
+ * Get a target by UUID
+ */
+export function getTargetByUUID(project: xcode.Project, uuid: string) {
+  return project.pbxNativeTargetSection()[uuid];
+}

--- a/src/xcode.d.ts
+++ b/src/xcode.d.ts
@@ -2,7 +2,8 @@ declare module "xcode" {
   type Project = {
     parseSync(): Project;
     writeSync(): string;
-    getFirstTarget(): { uuid: string };
+    pbxNativeTargetSection(): { [index: string]: unknown };
+    getFirstProject(): { firstProject: { targets: { value: string }[] } };
     addResourceFile(
       filePath: string,
       options: { target: string },


### PR DESCRIPTION
Link assets for ALL targets in the project, instead of only the first target. This is technically a breaking change.

It's only been partially tested as I cannot get `build-for-npm.ts` to run properly.

Also I put a couple helper functions in a new `utils.ts` file. Let me know if there's a better place for them.