### PR TITLE
minor: Fix support for multiple iOS targets

### DIFF
--- a/src/copy-assets/ios.ts
+++ b/src/copy-assets/ios.ts
@@ -43,7 +43,10 @@ export default async function copyAssetsIos(
           }
         }
       } else {
+        // Each target & asset combination needs a different build phase UUID
         file.target = target;
+        file.uuid = project.generateUuid();
+        project.addToPbxBuildFileSection(file);
         project.addToPbxResourcesBuildPhase(file);
       }
     }

--- a/src/xcode.d.ts
+++ b/src/xcode.d.ts
@@ -2,6 +2,7 @@ export type PBXFile = {
   basename: string;
   path: string;
   target?: string;
+  uuid: string;
 };
 
 export type PBXProject = {
@@ -13,11 +14,13 @@ export type PBXProject = {
     filePath: string,
     options: { target: string },
   ): PBXFile | false;
+  addToPbxBuildFileSection(file: PBXFile): void;
   addToPbxResourcesBuildPhase(file: PBXFile): void;
   removeResourceFile(
     filePath: string,
     options: { target: string },
   ): PBXFile;
+  generateUuid(): string;
   hash: string;
 };
 

--- a/test/mod.test.ts
+++ b/test/mod.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { linkAssets } from "@unimonkiez/react-native-asset";
 import { setupLinkAssetsMocks } from "./test-tools.ts";
 import testProjectPbxproj from "./test_project.pbxproj" with { type: "text" };
@@ -322,6 +326,34 @@ Deno.test("linkAssets links fonts to all iOS targets in the project", async () =
       "../assets/font.ttf",
     );
 
+    const buildFileSection = newTestProjectPbxproj.slice(
+      newTestProjectPbxproj.indexOf(
+        "/* Begin PBXBuildFile section */",
+      ),
+      newTestProjectPbxproj.indexOf(
+        "/* End PBXBuildFile section */",
+      ),
+    );
+    const buildFileSectionLinesWithFont = buildFileSection.split("\n")
+      .filter((s) => s.includes("font.ttf"));
+
+    // Font should be in the build file section twice (once for each target)
+    assertEquals(buildFileSectionLinesWithFont.length, 2);
+
+    const fileReferenceSection = newTestProjectPbxproj.slice(
+      newTestProjectPbxproj.indexOf(
+        "/* Begin PBXFileReference section */",
+      ),
+      newTestProjectPbxproj.indexOf(
+        "/* End PBXFileReference section */",
+      ),
+    );
+    const fileReferenceSectionLinesWithFont = fileReferenceSection.split("\n")
+      .filter((s) => s.includes("font.ttf"));
+
+    // Font should be in the file reference section once
+    assertEquals(fileReferenceSectionLinesWithFont.length, 1);
+
     const resourcesBuildPhase = newTestProjectPbxproj.slice(
       newTestProjectPbxproj.indexOf(
         "/* Begin PBXResourcesBuildPhase section */",
@@ -330,9 +362,17 @@ Deno.test("linkAssets links fonts to all iOS targets in the project", async () =
         "/* End PBXResourcesBuildPhase section */",
       ),
     );
+    const resourcesBuildPhaseLinesWithFont = resourcesBuildPhase.split("\n")
+      .filter((s) => s.includes("font.ttf"));
 
     // Font should be in the resources build phase twice (once for each target)
-    assertEquals(resourcesBuildPhase.split("font.ttf").length - 1, 2);
+    assertEquals(resourcesBuildPhaseLinesWithFont.length, 2);
+
+    const firstUuid = resourcesBuildPhaseLinesWithFont[0].slice(4, 28);
+    const secondUuid = resourcesBuildPhaseLinesWithFont[1].slice(4, 28);
+
+    // Font should have different UUID in each build phase
+    assertNotEquals(firstUuid, secondUuid);
 
     // Font should be added to UIAppFonts in BOTH Info.plist files
     assertStringIncludes(


### PR DESCRIPTION
Due to my misunderstanding of the `project.pbxproj` file structure, the feature to link assets for all iOS targets produced a malformed file incompatible with `pod install`.

This PR changes the following:
- Each combination of asset & target has a distinct UUID in the `PBXResourcesBuildPhase` section
- Each combination of asset & target has an entry in the `PBXBuildFile` section referencing said UUID
- Expands tests to ensure asset is linked in all the right places in `project.pbxproj`

Fixes #80 